### PR TITLE
add alias expantion

### DIFF
--- a/watch.plugin.zsh
+++ b/watch.plugin.zsh
@@ -23,6 +23,11 @@ watch-command-line() {
         LBUFFER="${LBUFFER:1}"
     fi
 
+    # Expand aliases
+    unset 'functions[_watch-plugin-expand]' # Clear function set by previous call
+    functions[_watch-plugin-expand]=${LBUFFER} # Save LBUFFER to functions file, this will expand the aliases
+    (($+functions[_watch-plugin-expand])) && LBUFFER=${functions[_watch-plugin-expand]#$'\t'} # Get the (expanded) function content back and clear the first tab(s)
+
     if [[ $BUFFER == watch\ * ]]; then
         if [[ ${#LBUFFER} -le 5 ]]; then
             RBUFFER="${BUFFER#watch }"


### PR DESCRIPTION
I'd like to propose an improvement for the plugin.
As you may know the `watch` command doesn't allow the use of aliases.
For example this doesn't work:
```shell
alias o="ls -l"
watch o
```
But there is a way to expand aliases, based on [this](https://unix.stackexchange.com/a/150737) post, which I would like to see in this plugin.